### PR TITLE
Fix: declare $settingOptionGroup in Settings.php to silence warnings

### DIFF
--- a/Admin/Settings.php
+++ b/Admin/Settings.php
@@ -68,6 +68,13 @@ class Settings extends SettingsBase
     private $settingsPage;
 
     /**
+     * @var string Name of group of setting options.
+     * 
+     * @since    1.0.0
+     */
+    private $settingOptionGroup;
+
+    /**
      * @var string Name of general options. Expected to not be SQL-escaped.
      *
      * @since    1.0.0


### PR DESCRIPTION
# Description

Hello. I have found this wonderful plugin in plugin directory, but I found some warnings after installation.

This PR add a declaration of property in Admin/Settings.php. Before this fix, there was some warnings displayed on admin  dashboard like below.
<details><summary>Warnings from PHP</summary><div>

`
Deprecated: Creation of dynamic property VaakyHighlighter\Admin\Settings::$settingOptionGroup is deprecated in /var/www/html/wp-content/plugins/vaaky-highlighter/Admin/Settings.php on line 98 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-content/plugins/vaaky-highlighter/Admin/Settings.php:98) in /var/www/html/wp-admin/includes/misc.php on line 1431 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-content/plugins/vaaky-highlighter/Admin/Settings.php:98) in /var/www/html/wp-includes/functions.php on line 7049 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-content/plugins/vaaky-highlighter/Admin/Settings.php:98) in /var/www/html/wp-admin/admin-header.php on line 9 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-content/plugins/vaaky-highlighter/Admin/Settings.php:98) in /var/www/html/wp-includes/option.php on line 1478 Warning: Cannot modify header information - headers already sent by (output started at /var/www/html/wp-content/plugins/vaaky-highlighter/Admin/Settings.php:98) in /var/www/html/wp-includes/option.php on line 1479
`
</div></details>

So, I declared $settingOptionGroup in Settings.php. The messages above are all disappeared after this fix.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Tested vaaky highlighter gutenberg blocks
- [x] Tested as how it has been render in fronted

**Test Configuration**:
* WordPress version: 6.4.2
* PHP Version: 8.2.14
* Theme Name:  Twenty Twenty-Four
* Theme Version: 1.0

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New unit tests pass locally with my changes (_if applicable_)
- [x] Any dependent changes have been merged and published in downstream modules
